### PR TITLE
Add Jet support

### DIFF
--- a/batrun/subfits_jet
+++ b/batrun/subfits_jet
@@ -1,0 +1,67 @@
+set -euax
+
+EXPNAM=$1 CDATE=$2 COMROT=${3:-$STMP/$USER} ARCDIR=${4:-$COMROT/archive} TMPDIR=${5:-$STMP/$USER/tmpdir}
+
+ACCOUNT=${ACCOUNT:-hfv3gfs}
+CUE2RUN=${CUE2RUN:-dev}
+KEEPDATA=${KEEPDATA:-NO}
+
+vday=$(echo $CDATE | cut -c1-8)
+vcyc=$(echo $CDATE | cut -c9-10)
+
+echo -------------------------------------------------------------------------------------------------------------------
+echo Starting the runfits for:
+echo -------------------------------------------------------------------------------------------------------------------
+echo "EXPNAM    " $EXPNAM       # argument 1 - experiment name    - required  (can be prod in which case COMROT is moot)
+echo "CDATE     " $CDATE        # argument 2 - date of validation - required 
+echo "COMROT    " $COMROT       # argument 3 - COMROT directory   - optional - defaults to /stmp/$USER
+echo "ARCDIR    " $ARCDIR       # argument 4 - ARCDIR directory   - optional - defaults to $COMROT/archive 
+echo "TMPDIR    " $TMPDIR       # argument 5 - TMPDIR directory   - optional - defaults to /stmp/$USER/tmpdir
+echo "ACCOUNT   " $ACCOUNT      # inherited  - project code       - required - defaults to nothing  
+echo "KEEPDATA  " $KEEPDATA     # inherited  - retain rundir      - optional - defaults to NO (rmdir)
+echo -------------------------------------------------------------------------------------------------------------------
+
+fitdir=${fitdir:-$(dirname $0)}; fitdir=$(cd $fitdir; pwd)
+COMDAY=${COMDAY:-$COMROT/logs/$CDATE}
+
+set -euax          
+
+vrfytmpdiris=$TMPDIR
+unset TMPDIR
+
+cat<<EOF | sbatch
+#!/bin/bash
+#SBATCH --job-name=FITS.$EXPNAM.$CDATE --time=00:20:00
+#SBATCH --nodes=3 --ntasks-per-node=1
+#SBATCH --mem=128G
+#SBATCH --output=$COMDAY/jet.fit2obs.log.$$
+#SBATCH --account=$ACCOUNT  
+#SBATCH --qos=batch 
+
+set -euax
+
+set +x
+module use /lfs4/HFIP/hfv3gfs/role.epic/hpc-stack/libs/intel-2022.1.2/modulefiles/stack
+module load  hpc/1.2.0  hpc-intel/2022.1.2  hpc-impi/2022.1.2
+module load netcdf/4.7.4
+module list
+set -x
+
+export OMP_NUM_THREADS=${FITOMP:-1}
+export MPIRUN="srun --export=ALL -n 3 --mem=0"
+
+export CDATE=$CDATE
+export EXP=$EXPNAM
+export COMPONENT=${COMPONENT:-atmos}
+export COM_IN=$ROTDIR
+export KEEPDATA=$KEEPDATA
+
+export fitdir=$fitdir
+export ARCDIR=$ARCDIR
+export TMPDIR=$vrfytmpdiris
+export ACPROFit=${ACPROFit:-YES}
+export NEMS=${NEMS:-YES}   
+
+time $fitdir/runfits $EXPNAM $CDATE $COMROT
+
+EOF

--- a/modulefiles/fit2obs_jet.lua
+++ b/modulefiles/fit2obs_jet.lua
@@ -1,0 +1,27 @@
+help([[
+Build environment for fit2obs on Jet
+]])
+
+prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/role.epic/hpc-stack/libs/intel-18.0.5.274/modulefiles/stack")
+
+local hpc_ver=os.getenv("hpc_ver") or "1.2.0"
+local hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.5.274"
+local hpc_impi_ver=os.getenv("hpc_impi_ver") or "2018.4.274"
+local cmake_ver=os.getenv("cmake_ver") or "3.20.1"
+
+local jasper_ver=os.getenv("jasper_ver") or "2.0.25"
+local zlib_ver=os.getenv("zlib_ver") or "1.2.11"
+local libpng_ver=os.getenv("libpng_ver") or "1.6.35"
+
+load(pathJoin("hpc", hpc_ver))
+load(pathJoin("hpc-intel", hpc_intel_ver))
+load(pathJoin("hpc-impi", hpc_impi_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load(pathJoin("jasper", jasper_ver))
+load(pathJoin("zlib", zlib_ver))
+load(pathJoin("libpng", libpng_ver))
+
+load("fit2obs_common")
+
+whatis("Description: fit2obs environment on Jet with Intel Compilers")


### PR DESCRIPTION
This adds the ability to compile and run Fit2Obs on Jet.  A 25-cycle run has been completed on Jet using these updates and the global workflow branch [port_2_jet](https://github.com/DavidHuber-NOAA/global-workflow/tree/port_2_jet).  The logs and archive (including fits) have been transferred to Hera:
archive: /scratch2/NESDIS/nesdis-rdo1/David.Huber/jet_archive/ur_192
logs: /scratch2/NESDIS/nesdis-rdo1/David.Huber/jet_logs/ur_192
@jack-woollen Could you review the outputs and logs?

It should be noted that this test was completed with unrestricted (henc `ur`) data.